### PR TITLE
Update PacketEvents to 2.13.0

### DIFF
--- a/Plugin/build.gradle.kts
+++ b/Plugin/build.gradle.kts
@@ -197,11 +197,11 @@ dependencies {
     //Paper
     compileOnly("io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT")
     //compileOnly "com.comphenix.protocol:ProtocolLib:5.1.0"
-    libby("com.github.retrooper:packetevents-spigot:2.12.1")
+    libby("com.github.retrooper:packetevents-spigot:2.13.0")
 
     //PacketEvents for Velocity and BungeeCord
-    libby("com.github.retrooper:packetevents-velocity:2.12.1")
-    libby("com.github.retrooper:packetevents-bungeecord:2.12.1")
+    libby("com.github.retrooper:packetevents-velocity:2.13.0")
+    libby("com.github.retrooper:packetevents-bungeecord:2.13.0")
 
     compileOnly("io.netty:netty-transport:4.2.9.Final")
     compileOnly("com.mojang:datafixerupper:8.0.16") //I hate this so much


### PR DESCRIPTION
Fixes Velocity injection errors (NoSuchFieldError: PacketEventsDecoder.player, NoSuchElementException: packet-decoder, and channel initializer uninject failure) that occurred because the cached 2.12.1 jar did not match its expected bytecode. 2.13.0 includes the upstream fix for injection cleanup issues on Velocity (#1489) and adds support for Minecraft 26.2.

Note: Generated with AI, and tested on my server with no errors. 